### PR TITLE
bugfix: handle file moves

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = typescriptnamespaceimports
 pluginName = Typescript Namespace Imports
 pluginRepositoryUrl = https://github.com/echentw/typescript-namespace-imports-webstorm-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.2
+pluginVersion = 0.2.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242


### PR DESCRIPTION
- need to use the old path
- don't have `VirtualFile` objects for the old paths, so need to change the code to accept file paths (string) instead of `VirtualFile`